### PR TITLE
fix(foursquare): OAUTH_PARSE_PROFILE_ERROR

### DIFF
--- a/packages/core/src/providers/foursquare.js
+++ b/packages/core/src/providers/foursquare.js
@@ -1,6 +1,6 @@
 /** @type {import(".").OAuthProvider} */
 export default function Foursquare(options) {
-  const { apiVersion = "20210801" } = options
+  const { apiVersion = "20230131" } = options
   return {
     id: "foursquare",
     name: "Foursquare",
@@ -15,7 +15,7 @@ export default function Foursquare(options) {
         return fetch(url).then((res) => res.json())
       },
     },
-    profile({ response: { profile } }) {
+    profile({ response: { user: profile } }) {
       return {
         id: profile.id,
         name: `${profile.firstName} ${profile.lastName}`,


### PR DESCRIPTION
## ☕️ Reasoning

I created a fresh Next.js app, installed next-auth, and tried to set it up with the Foursquare provider.

When I tried to log-in, I saw this next-auth OAUTH error:
```
[next-auth][error][OAUTH_PARSE_PROFILE_ERROR] 
https://next-auth.js.org/errors#oauth_parse_profile_error Cannot read properties of undefined (reading 'id') {
  error: {
    message: "Cannot read properties of undefined (reading 'id')",
    stack: "TypeError: Cannot read properties of undefined (reading 'id')\n" +
...
```

I went ahead and followed [this guide](https://location.foursquare.com/developer/reference/authentication-v2) to check what data Foursquare returns to this request (I used `20210821` as apiVersion param since this was the default)

`curl https://api.foursquare.com/v2/users/self/checkins?oauth_token=ACCESS_TOKEN&v=YYYYMMDD`

And it looks like Foursquare returns the data under a `user` key instead of `profile`, causing the `OAUTH_PARSE_PROFILE_ERROR`.

Example response:

```
{
	"meta": {
		"code": 200,
		"requestId": "..."
	},
	"notifications": [
		{
			"type": "notificationTray",
			"item": {
				"unreadCount": 0
			}
		}
	],
	"response": {
		"user": {
			"id": "...",
			"firstName": "...",
			"lastName": "...",
			"gender": "male",
			"address": "",
			"city": "",
			"state": "",
			"countryCode": "..",
			"relationship": "self",
			"canonicalUrl": "https:\/\/foursquare.com\/user\/...",
			"photo": {
				"prefix": "https:\/\/fastly.4sqi.net\/img\/user\/",
				"suffix": "..."
			},
	},
	...
}
```

You can create a new Foursquare OAuth applicaion and test the request here: https://location.foursquare.com/developer/reference/v2-users-user_id


## 🧢 Checklist

- [x] Documentation - no need to update docs in my opinion
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
